### PR TITLE
Makefile: enable DEBUG option by default

### DIFF
--- a/oei/common/Makefile
+++ b/oei/common/Makefile
@@ -4,10 +4,8 @@ include $(ROOT_DIR)/oei/$(OEI)/Makefile
 OBJS += \
 	$(OUT)/oei_entry.o
 
-ifeq ($(DEBUG), 1)
 OBJS += \
 	$(OUT)/printf.o
-endif
 
 INCLUDE += -I$(ROOT_DIR)/oei/common -I$(ROOT_DIR)/oei/$(OEI)
 INCLUDE += -I$(SOC_DEVICE_DIR) -I$(SOC_DEVICE_DIR)/oei

--- a/oei/common/oei.h
+++ b/oei/common/oei.h
@@ -42,10 +42,6 @@
 #define Write16(a,v)  (*(volatile uint16_t *)(a) = (v))
 /** @} */
 
-#if !defined(DEBUG)
-#define printf(...)
-#endif
-
 /**
  * OEI main function
  *


### PR DESCRIPTION
Without the DEBUG option there is no output from OEI. Also the messages, that get enabled by this option are not really "debug" messages, but rather general messages. Enable this option by default to have at least some status info printed by OEI.