### PR TITLE
fix no DEBUG build

### DIFF
--- a/boards/mx95libra/Makefile
+++ b/boards/mx95libra/Makefile
@@ -14,11 +14,9 @@ INCLUDE +=  \
 	-I$(BOARDS_DIR)  \
 	-I$(BOARD_DIR)
 
-ifeq ($(DEBUG),1)
 OBJS += \
 	$(OUT)/board.o  \
 	$(OUT)/pin_mux.o
-endif
 
 VPATH +=  \
 	$(BOARDS_DIR)  \

--- a/devices/MIMX95/oei/Makefile
+++ b/devices/MIMX95/oei/Makefile
@@ -50,10 +50,8 @@ SDK_OBJS = \
     $(OUT)/fsl_src.o  \
     $(OUT)/fsl_sysctr.o
 
-ifeq ($(DEBUG),1)
 SDK_OBJS += \
     $(OUT)/fsl_lpuart.o
-endif
 
 OBJS  +=  \
     $(OUT)/soc_clock.o  \


### PR DESCRIPTION
fix build when DEBUG option is not enabled.

Fixes: f306b1f98d0f ("Makefile: do not disable printf globally when DEBUG is not set")
