### PR TITLE
fix oei ddr hangs on boot when DEBUG is not enabled

### DIFF
--- a/oei/ddr/main.c
+++ b/oei/ddr/main.c
@@ -93,10 +93,8 @@ int oei_main(uint32_t argc, uint32_t *argv)
         timer_enable();
 
     Clock_Init();
-#ifdef DEBUG
     BOARD_InitPins();
     BOARD_InitDebugConsole();
-#endif
 
     printf("\nDDR OEI: (Build %lu, Commit %08lx, %s %s)\n\n",
         OEI_BUILD, OEI_COMMIT, OEI_DATE, OEI_TIME);

--- a/oei/tcm/main.c
+++ b/oei/tcm/main.c
@@ -22,10 +22,8 @@ int oei_main(uint32_t argc, uint32_t *argv)
 		timer_enable();
 
 	Clock_Init();
-#ifdef DEBUG
 	BOARD_InitPins();
 	BOARD_InitDebugConsole();
-#endif
 
 	printf("\n\nTCM OEI: start\n");
 #ifdef DEBUG


### PR DESCRIPTION
When debug build was not enabled, oei/ddr was hanging during boot because the init function for debug console is deactivated. In oei/tcm the functions are also disabled, but it does not hang. Probably because the printf does not work in tcm oei at the moment.

Fixes: f306b1f98d0f ("Makefile: do not disable printf globally when DEBUG is not set")